### PR TITLE
added POST request utility method

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@
   * chart.addData(data [number | array], label [string], color [hex color]);
   * chart.setAutoScaling();
   * chart.getUrl(https [boolean]); // true = https, false = http
+  * chart.getPostReq(https [boolean], callback [function]);
 
 ### Pie
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,31 +1,54 @@
-3
-var apiUrl = 'chart.googleapis.com/chart?';
+var http = require('http')
+  , https = require('https')
+  , querystring = require('querystring')
+  , apiUrl = 'chart.googleapis.com/chart'
+  , getUrl = apiUrl + '?';
 
 module.exports = {
   'createUrl': function(chart, secure) {
-    var params = {};
+    var params = compileParams(chart)
+      , options = [];
 
-    params = _merge(params, processType(chart));
-    params = _merge(params, processTitle(chart));
-    params = _merge(params, processData(chart));
-    params = _merge(params, processLineStyle(chart));
-    params = _merge(params, processAxisLabels(chart));
-    params = _merge(params, processBarWidthSpacing(chart));
-    params = _merge(params, processLegend(chart));
-    params = _merge(params, processSize(chart));
-    params = _merge(params, processBackground(chart));
-    params = _merge(params, processEncoding(chart));
-    params = _merge(params, processLabel(chart));
-    params = _merge(params, processLabelData(chart));
-
-    var options = [];
     for(var param in params) {
       options.push([param, params[param]].join('='));
     }
 
-    return ((secure) ? 'https://' : 'http://') + apiUrl + options.join('&');
+    return ((secure) ? 'https://' : 'http://') + getUrl + options.join('&');
+  },
+  'getPostReq': function(chart, secure, callback) {
+    var params = compileParams(chart)
+      , payload = querystring.stringify(params)
+      , options = {
+          hostname: 'chart.googleapis.com',
+          path: '/chart',
+          method: 'POST'
+        }
+      , type = secure ? https : http
+      , req = type.request(options, callback);
+
+    req.write(payload);
+
+    return req;
   }
 };
+
+function compileParams(chart){
+  var params = {};
+  params = _merge(params, processType(chart));
+  params = _merge(params, processTitle(chart));
+  params = _merge(params, processData(chart));
+  params = _merge(params, processLineStyle(chart));
+  params = _merge(params, processAxisLabels(chart));
+  params = _merge(params, processBarWidthSpacing(chart));
+  params = _merge(params, processLegend(chart));
+  params = _merge(params, processSize(chart));
+  params = _merge(params, processBackground(chart));
+  params = _merge(params, processEncoding(chart));
+  params = _merge(params, processLabel(chart));
+  params = _merge(params, processLabelData(chart));
+
+  return params
+}
 
 function processSize(chart) {
   return {

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -2,7 +2,7 @@
 // http://code.google.com/apis/chart/image/
 // http://code.google.com/apis/chart/image/docs/chart_params.html
 
-var url = require('./url');
+var api = require('./api');
 
 var Chart = function() {};
 
@@ -165,7 +165,11 @@ Chart.prototype.getAxisLabel = function(name) {
 }
 
 Chart.prototype.getUrl = function(secure) {
-  return url.createUrl(this, secure);
+  return api.createUrl(this, secure);
+};
+
+Chart.prototype.getPostReq = function(secure, callback) {
+  return api.getPostReq(this, secure, callback);
 };
 
 module.exports = Chart;


### PR DESCRIPTION
I was using quiche (really nice to work with), and bumped into the 2040 character limit on GET requests.
POST requests can handle way more data points (up to 16k characters I believe), so I added a little method that returns a basic `require(['http' || 'https']).request` POST request pointing at your chart.

I added it to url.js because it uses the same resources so I changed the name to api.js (now containing both GET url and POST request methods)

So now I do
```javascript
var tofile = fs.createWriteStream('chart.png')
chart.getPostReq(true, function(res){
  res.pipe(tofile)
}).end()
```
and I have my (big) chart!

Thanks for quiche and have a good day,

Marcus